### PR TITLE
Sno default worker nodes

### DIFF
--- a/calculation/ObsSizingTemplate-Rev1.ipynb
+++ b/calculation/ObsSizingTemplate-Rev1.ipynb
@@ -536,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -675,6 +675,11 @@
     "number_of_hours_pv_retention_hrs=24\n",
     "number_of_days_for_storage=365\n",
     "\n",
+    "# default number of workers is 3 considering compact clusters as default\n",
+    "# but should be 1 when working with snos\n",
+    "number_of_default_worker_nodes=3\n",
+    "if number_of_master_node==1:\n",
+    "  number_of_default_worker_nodes=1\n",
     "\n",
     "# Present Sizing for Object Store\n",
     "input_data = {'Specs': ['Number of Managed Clusters',  \n",
@@ -695,7 +700,7 @@
     "                  number_of_addn_worker_nodes+number_of_master_node,\n",
     "                  number_of_vcore_per_node,\n",
     "                  number_of_application_pods_per_node,\n",
-    "                  number_of_application_pods_per_node*(number_of_addn_worker_nodes+3),\n",
+    "                  number_of_application_pods_per_node*(number_of_addn_worker_nodes+number_of_default_worker_nodes),\n",
     "                  number_of_ns,\n",
     "                  number_of_container_per_pod,\n",
     "                  number_of_samples_per_hour,\n",
@@ -901,7 +906,7 @@
     "if number_of_master_node != 1:\n",
     "  # if not an SNO, affected by workers multipliers\n",
     "  for x in pod_multiplier.values():\n",
-    "    temp= (number_of_addn_worker_nodes+3)*number_of_application_pods_per_node*x\n",
+    "    temp= (number_of_addn_worker_nodes+number_of_default_worker_nodes)*number_of_application_pods_per_node*x\n",
     "    number_of_ts_for_all_pod=number_of_ts_for_all_pod+temp\n",
     "  print(\"number_of_ts_for_all_pod: \",number_of_ts_for_all_pod)\n",
     "\n",


### PR DESCRIPTION
it tries to use better calculation on worker nodes number, when SNO. I only did a change for a print on number of pods on clusters (on SNO, should be the same than per node). 

Other one on Pod Multiplier calculation. For this one I need a review.

I hope this does not affect to other logic/calculation. It needs a good review :) 
